### PR TITLE
Dockerfile fix and envar support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM golang:1.20-alpine as builder
 RUN apk add --no-cache git make g++ gzip
 WORKDIR /go/share
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,4 @@ FROM alpine:latest
 VOLUME /data
 EXPOSE 8222
 COPY --from=builder /go/bin/share /share
-ENV url "http://localhost:8222"
-CMD ["sh","-c","/share --debug --min-per-gig 120 --max-file 500000000 --data /data --public ${url}"]
+CMD ["sh","-c","/share"]


### PR DESCRIPTION
Your recent update switching from go-bindata to embed broke the Dockerfile, as embed was only added from go 1.15 onwards. I've made the following changes while I fixed that:

- Removed hard coded arguments in Dockerfile
- Introduced environment variables overwriting values for flags if they are present
- Removed deprecation warnings by changing io/ioutli to os and io packages 